### PR TITLE
CSS overrides for Slovak and Czech

### DIFF
--- a/app/locale/README.md
+++ b/app/locale/README.md
@@ -21,7 +21,7 @@ Available/Supported langs (based on [steam](https://partner.steamgames.com/doc/s
 
 Translation Status
 ==================
-As of 12/09/2019 | dd-mm-yyyy
+As of 16/01/2026 | dd-mm-yyyy
 
 - Arabic (ar) | العربية
 - Bulgarian (bg) | български език
@@ -30,7 +30,9 @@ As of 12/09/2019 | dd-mm-yyyy
     No css override <br/>
     [fiyeck](https://github.com/fiyeck)
 - Chinese: Traditional (zh-TW) | 繁體中文	
-- Czech (cs) | čeština	
+- Czech (cs) | čeština
+   <br/>Css override <br/>
+    procyon99
 - Danish (da) | Dansk	
 - Dutch (nl) | Nederlands	
 - English (en) | English
@@ -76,6 +78,9 @@ As of 12/09/2019 | dd-mm-yyyy
     Css override <br/>
     [hugmouse](https://github.com/hugmouse)
     [kochetov2000](https://github.com/kochetov2000)
+- Slovak (sk) | slovenčina
+   <br/>Css override <br/>
+    procyon99
 - Spanish (es) | Español-España
     <br/> Complete <br/>
     Css override <br/>

--- a/app/locale/lang/czech.json
+++ b/app/locale/lang/czech.json
@@ -40,12 +40,12 @@
     "overlay": {
       "position": "Pozice oznámení",
       "preset": {
-        "name": "Předvolené nastavení oznámení",
+        "name": "Výchozí nastavení oznámení",
         "description": "Legacy používá starý systém oznámení"
       },
       "hotkey": {
         "name": "Klávesová zkratka pro overlay",
-        "description": "Během hry můžete stisknout tuto klávesovou zkratku pro zobrazení achievementů této hry."
+        "description": "Během hry můžete stisknout tuto klávesovou zkratku pro zobrazení achievementů této hry"
       },
       "scale": "Měřítko oznámení",
       "duration": "Trvání animace"
@@ -77,7 +77,7 @@
         }
       },
       "hideZero": {
-        "name": "Skrýt hry s 0 % odemčených achievementů"
+        "name": "Skrýt 0 % hry"
       }
     },
     "notification": {
@@ -93,15 +93,15 @@
       "option": {
         "notification": {
           "name": "Oznámení",
-          "description": "Pokud je to možné, upozornit na odemčení achievementu"
+          "description": "Je-li to možné, upozornit na odemčení achievementu"
         },
         "rumble": {
           "name": "Vibrace gamepadu (XInput)",
-          "description": "Při odemčení achievementu zavibruje první ovladač"
+          "description": "Při odemčení achievementu zavibruje první gamepad"
         },
         "notifyOnProgress": {
           "name": "Postup achievementu",
-          "description": "Pokud je to možné, dostávat oznámení o postupu jednotlivých achievementů"
+          "description": "Je-li to možné, dostávat oznámení o postupu jednotlivých achievementů"
         },
         "playtime": {
           "name": "Sledování herního času",
@@ -133,7 +133,7 @@
         },
         "useWinRT": {
           "name": "WinRT API",
-          "description": "Pokud je k dispozici, použije WinRT pro rychlejší zobrazení oznámení místo PowerShellu."
+          "description": "Je-li k dispozici, použije WinRT pro rychlejší zobrazení oznámení místo PowerShellu"
         },
         "useBalloon": {
           "name": "Bublinová nápověda",
@@ -156,7 +156,7 @@
       "option": {
         "screenshot": {
           "name": "Suvenýr",
-          "description": "Při odemčení achievementu vytvoří snímek obrazovky"
+          "description": "Při odemčení achievementu pořídí snímek obrazovky"
         },
         "video": {
           "name": "Video suvenýr",
@@ -177,7 +177,7 @@
           "description": "10 bitů je dostupných pouze pro H.265/HEVC"
         },
         "duration": {
-          "name": "Délka"
+          "name": "Trvání"
         },
         "framerate": {
           "name": "Snímková frekvence"
@@ -192,7 +192,7 @@
       "default": "Výchozí adresář",
       "custom": "Uživatelský adresář",
       "addInfo": [
-        "Vyberte složku, která obsahuje složku/složky appid.",
+        "Vyberte složku, která obsahuje složku/složky AppID.",
         "Pro ALI213, Hoodlum, Tenoke, UniverseLAN, RPCS3 prosím vyberte složku, kde",
         "se nachází soubor ALI213.ini, valve.ini, hlm.ini, ds.ini, steam_api.ini, SteamConfig.ini, tenoke.ini, UniverseLAN.ini nebo RPCS3.exe."
       ],
@@ -222,7 +222,7 @@
       },
       "importCache": {
         "name": "Importovat cache oznámení",
-        "description": "Importovat cache z Watchdog jako další zdroj achievementů"
+        "description": "Importovat cache z watchdog jako další zdroj achievementů"
       }
     },
     "advanced": {

--- a/app/locale/lang/czech.json
+++ b/app/locale/lang/czech.json
@@ -19,7 +19,7 @@
     "title": "Nastavení",
     "sideMenu": {
       "general": "Obecné",
-      "overlay": "Overlay",
+      "overlay": "Překrytí",
       "notification": "Oznámení",
       "souvenir": "Suvenýr",
       "folder": "Složky",
@@ -37,15 +37,16 @@
       "version": "Verze",
       "edit": "Upravit"
     },
+    "watchdog": {
+      "startup": { "name": "Spustit při přihlášení", "description": "Watchdog se spustí automaticky při startu systému" },
+      "kill": { "name": "Ponechat spuštěný", "description": "Watchdog zůstane spuštěný i po zavření hlavní aplikace" }
+    },
     "overlay": {
       "position": "Pozice oznámení",
-      "preset": {
-        "name": "Výchozí nastavení oznámení",
-        "description": "Legacy používá starý systém oznámení"
-      },
+      "preset": { "name": "Výchozí nastavení oznámení", "description": "Legacy používá starý systém oznámení" },
       "hotkey": {
-        "name": "Klávesová zkratka pro overlay",
-        "description": "Během hry můžete stisknout tuto klávesovou zkratku pro zobrazení achievementů této hry"
+        "name": "Klávesová zkratka pro překrytí",
+        "description": "Stisknutím této klávesové zkratky během hry zobrazíte překrytí s achievementy"
       },
       "scale": "Měřítko oznámení",
       "duration": "Trvání animace"
@@ -78,14 +79,16 @@
       },
       "hideZero": {
         "name": "Skrýt 0 % hry"
-      }
+      },
+	  "tray": { "name": "Zavřít do oblasti oznámení", "description": "Nechat aplikaci běžet na pozadí, aby se oznámení spouštěla rychleji" }
     },
     "notification": {
       "title": {
         "common": "Obecné",
         "toast": "Vyskakovací oznámení",
         "transport": "Transport",
-        "chromium": "Oznámení Chromium"
+        "chromium": "Oznámení Chromium",
+        "watchdog": "Watchdog"
       },
       "info": {
         "toast": "Některé funkce jsou dostupné pouze v systému Windows 10"
@@ -117,7 +120,7 @@
         },
         "toastSouvenir": {
           "name": "Suvenýr v oznámení",
-          "description": "Zobrazit snímek obrazovky suvenýru v oznámení",
+          "description": "Zobrazit suvenýrový snímek obrazovky v oznámení",
           "value": {
             "top": "Nahoře",
             "bottom": "Dole"
@@ -193,7 +196,7 @@
       "custom": "Uživatelský adresář",
       "addInfo": [
         "Vyberte složku, která obsahuje složku/složky AppID.",
-        "Pro ALI213, Hoodlum, Tenoke, UniverseLAN, RPCS3 prosím vyberte složku, kde",
+        "Pro ALI213, Hoodlum, TENOKE, UniverseLAN, RPCS3 prosím vyberte složku, kde",
         "se nachází soubor ALI213.ini, valve.ini, hlm.ini, ds.ini, steam_api.ini, SteamConfig.ini, tenoke.ini, UniverseLAN.ini nebo RPCS3.exe."
       ],
       "add": "Přidat složku"
@@ -230,7 +233,7 @@
       "blacklistButton": "Vynulovat černou listinu",
       "blacklistInfo": "Pro přidání hry na černou listinu klikněte pravým tlačítkem myši na kartu hry",
       "mainSteam": {
-        "title": "Hlavní účet na Steamu",
+        "title": "Hlavní účet služby Steam",
         "name": "Filtrovat podle uživatele",
         "description": "Zobrazit achievementy ze Steamu pouze pro vybraný účet"
       }

--- a/app/locale/lang/slovak.json
+++ b/app/locale/lang/slovak.json
@@ -8,9 +8,9 @@
   "locked": "Zamknuté",
   "globalStat": "hráčov získalo",
   "hiddenRemain": "skrytých achievementov ostáva",
-  "revealedOnceUnlocked": "Podrobnosti o každom z achievementov sa zobrazia po jeho odomknutí",
+  "revealedOnceUnlocked": "Podrobnosti o každom achievemente sa zobrazia po jeho odomknutí",
   "noneUnlocked": "Zatiaľ nebol odomknutý žiadny achievement",
-  "play": "Začnite hrať !",
+  "play": "Začnite hrať!",
   "scrollUp": "Posunúť nahor",
   "allGamesBackButton": "Všetky hry",
   "removeFromList": "Odstrániť zo zoznamu",
@@ -37,15 +37,16 @@
       "version": "Verzia",
       "edit": "Upraviť"
     },
+    "watchdog": {
+      "startup": { "name": "Spustiť pri prihlásení", "description": "Watchdog sa spustí automaticky pri štarte systému" },
+      "kill": { "name": "Ponechať spustený", "description": "Ponechať watchdog spustený aj po zatvorení hlavnej aplikácie" }
+    },
     "overlay": {
       "position": "Poloha oznámenia",
-      "preset": { 
-	   "name": "Predvolené nastavenie oznámení", 
-	   "description": "Legacy používa starý systém oznámení" 
-	  },
+      "preset": { "name": "Predvolené nastavenie oznámení", "description": "Legacy používa starý systém oznámení" },
       "hotkey": {
         "name": "Klávesová skratka pre prekrytie",
-        "description": "Počas hry môžete stlačiť túto klávesovú skratku, aby sa zobrazili achievementy tejto hry"
+        "description": "Počas hry stlačte túto klávesovú skratku pre zobrazenie prekrytia s achievementmi"
       },
       "scale": "Mierka oznámení",
       "duration": "Trvanie animácie"
@@ -72,20 +73,22 @@
         "name": "Zlúčenie časových značiek",
         "description": "Ktorá časová značka bude pri zlučovaní duplikátov preferovaná",
         "value": {
-          "recent": "Najnovšía",
+          "recent": "Najnovšia",
           "oldest": "Najstaršia"
         }
       },
       "hideZero": {
         "name": "Skryť 0 % hry"
-      }
+      },
+	  "tray": { "name": "Zavrieť do oblasti oznámení", "description": "Ponechať aplikáciu spustenú na pozadí, aby sa rýchlejšie spúšťali oznámenia" }
     },
     "notification": {
       "title": {
         "common": "Všeobecné",
         "toast": "Vyskakovacie oznámenie",
         "transport": "Transport",
-        "chromium": "Oznámenie Chromium"
+        "chromium": "Oznámenie Chromium",
+        "watchdog": "Watchdog"
       },
       "info": {
         "toast": "Niektoré funkcie sú dostupné iba v systéme Windows 10"
@@ -117,7 +120,7 @@
         },
         "toastSouvenir": {
           "name": "Suvenír v oznámení",
-          "description": "Zobraziť screenshot suveníru v oznámení",
+          "description": "Zobraziť suvenírovú snímku obrazovky v oznámení",
           "value": {
             "top": "Hore",
             "bottom": "Dole"
@@ -128,12 +131,12 @@
           "description": "Vizuálne zoskupiť upozornenia z rovnakej hry v Centre akcií"
         },
         "useToast": {
-          "name": "Vyskakovanie oznámenie",
-          "description": "Vyskakovanie oznámenie systémov Windows 8 a 10"
+          "name": "Vyskakovacie oznámenie",
+          "description": "Vyskakovacie oznámenie systémov Windows 8 a 10"
         },
         "useWinRT": {
           "name": "WinRT API",
-          "description": "Ak je k dispozícii, použije WinRT pre rýchlejšie zobrazenie oznámení namiesto PowerShell"
+          "description": "Ak je k dispozícii, použije WinRT pre rýchlejšie zobrazenie oznámení namiesto PowerShellu"
         },
         "useBalloon": {
           "name": "Bublinková nápoveda",
@@ -150,7 +153,7 @@
     },
     "souvenir": {
       "title": {
-        "screenshot": "Screenshot",
+        "screenshot": "Snímka obrazovky",
         "video": "Video"
       },
       "option": {
@@ -173,7 +176,7 @@
           "description": "H.265/HEVC sú výkonnejšie, ale menej podporované"
         },
         "colorDepth": {
-          "name": "Hĺbka farieb",
+          "name": "Farebná hĺbka",
           "description": "10 bitov je k dispozícii iba pre H.265/HEVC"
         },
         "duration": {
@@ -193,7 +196,7 @@
       "custom": "Adresár používateľa",
       "addInfo": [
         "Vyberte priečinok, ktorý obsahuje priečinok/priečinky AppID.",
-        "Pre ALI213, Hoodlum, Tenoke, UniverseLAN, RPCS3 prosím vyberte priečinok, kde",
+        "Pre ALI213, Hoodlum, TENOKE, UniverseLAN, RPCS3 prosím vyberte priečinok, kde",
         "sa nachádza súbor ALI213.ini, valve.ini, hlm.ini, ds.ini, steam_api.ini, SteamConfig.ini, tenoke.ini, UniverseLAN.ini alebo RPCS3.exe."
       ],
       "add": "Pridať priečinok"
@@ -230,7 +233,7 @@
       "blacklistButton": "Resetovať čiernu listinu",
       "blacklistInfo": "Pre pridanie hry na čiernu listinu kliknite pravým tlačidlom myši na kartu hry",
       "mainSteam": {
-        "title": "Hlavný účet na Steame",
+        "title": "Hlavný účet služby Steam",
         "name": "Filtrovať podľa používateľa",
         "description": "Zobraziť achievementy zo Steamu iba pre vybraný účet"
       }

--- a/app/locale/lang/slovak.json
+++ b/app/locale/lang/slovak.json
@@ -45,7 +45,7 @@
 	  },
       "hotkey": {
         "name": "Klávesová skratka pre prekrytie",
-        "description": "Počas hry môžete stlačiť túto klávesovú skratku, aby sa zobrazili achievementy tejto hry."
+        "description": "Počas hry môžete stlačiť túto klávesovú skratku, aby sa zobrazili achievementy tejto hry"
       },
       "scale": "Mierka oznámení",
       "duration": "Trvanie animácie"
@@ -77,7 +77,7 @@
         }
       },
       "hideZero": {
-        "name": "Skryť hry s 0% odomknutých achievemenov"
+        "name": "Skryť 0 % hry"
       }
     },
     "notification": {
@@ -133,7 +133,7 @@
         },
         "useWinRT": {
           "name": "WinRT API",
-          "description": "Ak je k dispozícii, použije WinRT pre rýchlejšie zobrazenie oznámení namiesto PowerShell."
+          "description": "Ak je k dispozícii, použije WinRT pre rýchlejšie zobrazenie oznámení namiesto PowerShell"
         },
         "useBalloon": {
           "name": "Bublinková nápoveda",
@@ -188,11 +188,11 @@
       }
     },
     "folder": {
-      "headline": "Kde hľadať súbory s achievementmi :",
+      "headline": "Kde hľadať súbory s achievementmi:",
       "default": "Predvolený adresár",
       "custom": "Adresár používateľa",
       "addInfo": [
-        "Vyberte priečinok, ktorý obsahuje priečinok/priečinky appid.",
+        "Vyberte priečinok, ktorý obsahuje priečinok/priečinky AppID.",
         "Pre ALI213, Hoodlum, Tenoke, UniverseLAN, RPCS3 prosím vyberte priečinok, kde",
         "sa nachádza súbor ALI213.ini, valve.ini, hlm.ini, ds.ini, steam_api.ini, SteamConfig.ini, tenoke.ini, UniverseLAN.ini alebo RPCS3.exe."
       ],
@@ -222,7 +222,7 @@
       },
       "importCache": {
         "name": "Importovať cache oznámení",
-        "description": "Importovať cache z Watchdog ako ďalší zdroj achievementov"
+        "description": "Importovať cache z watchdog ako ďalší zdroj achievementov"
       }
     },
     "advanced": {

--- a/app/locale/override.css
+++ b/app/locale/override.css
@@ -139,3 +139,26 @@ html[lang="zh-cn"] #options-souvenir-video li:nth-child(1).hasHelper.expand
 {
   margin-bottom: 16px;
 }
+
+html[lang="sk"] #user-info {
+  width: 820px;
+}
+html[lang="sk"] #options-ui li:nth-child(7).hasHelper,
+html[lang="sk"] #options-notify-common li:nth-child(3).hasHelper,
+html[lang="sk"] #options-notify-transport li:nth-child(3).hasHelper,
+html[lang="sk"] #options-notify-transport li:nth-child(4).hasHelper,
+html[lang="sk"] #options-source li:nth-child(1).hasHelper {
+  margin-bottom: 32px;
+}
+
+html[lang="cs"] #user-info {
+  width: 820px;
+}
+html[lang="cs"] #options-ui li:nth-child(7).hasHelper,
+html[lang="cs"] #options-notify-common li:nth-child(3).hasHelper,
+html[lang="cs"] #options-notify-transport li:nth-child(3).hasHelper,
+html[lang="cs"] #options-notify-transport li:nth-child(4).hasHelper,
+html[lang="cs"] #options-source li:nth-child(1).hasHelper {
+  margin-bottom: 32px;
+}
+

--- a/app/locale/steam.json
+++ b/app/locale/steam.json
@@ -23,6 +23,7 @@
   { "iso": "ru-RU", "displayName": "Russian", "api": "russian", "webapi": "ru", "native": "Русский" },
   { "iso": "es-ES", "displayName": "Spanish - Spain", "api": "spanish", "webapi": "es", "native": "Español-España" },
   { "iso": "es-419", "displayName": "Spanish - Latin America", "api": "latam", "webapi": "es-419", "native": "Español-Latinoamérica" },
+  { "iso": "sk-SK", "displayName": "Slovak", "api": "slovak", "webapi": "sk", "native": "slovenčina" },
   { "iso": "sv-SE", "displayName": "Swedish", "api": "swedish", "webapi": "sv", "native": "Svenska" },
   { "iso": "th-TH", "displayName": "Thai", "api": "thai", "webapi": "th", "native": "ไทย" },
   { "iso": "tr-TR", "displayName": "Turkish", "api": "turkish", "webapi": "tr", "native": "Türkçe" },


### PR DESCRIPTION
CSS overrides and translation refinements for Slovak and Czech.
Updated steam.json and localization readme.
Since Slovak is not an official Steam language, it might be considered to set its api and/or webapi to Czech to fetch Czech achievement descriptions for supported games.